### PR TITLE
Moved inline js to seperate module

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -525,5 +525,11 @@ jQuery(function () {
         import(/* webpackChunkName: "breadcrumb-select" */ './breadcrumb_select')
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
+    
+    const loans = document.querySelectorAll('.leave');
+    if (loans.length) {
+        import(/* webpackChunkName: "loans" */ './loans')
+            .then(module => module.initLoans(loans));
+    }
 
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -526,7 +526,7 @@ jQuery(function () {
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
     
-    const loans = document.querySelectorAll('.leave');
+    const loans = document.querySelectorAll('#leave-waitinglist-dialog');
     if (loans.length) {
         import(/* webpackChunkName: "loans" */ './loans')
             .then(module => module.initLoans(loans));

--- a/openlibrary/plugins/openlibrary/js/loans/index.js
+++ b/openlibrary/plugins/openlibrary/js/loans/index.js
@@ -1,0 +1,11 @@
+export function initLoans() {
+  window.q.push(function() {
+    $("a.leave").on('click', function() {
+      var title = $(this).parents("tr").find(".book").text();
+      $("#leave-waitinglist-dialog strong").text(title);
+      $("#leave-waitinglist-dialog")
+          .data("origin", $(this))
+          .dialog("open");
+    });
+  });
+}

--- a/openlibrary/plugins/openlibrary/js/loans/index.js
+++ b/openlibrary/plugins/openlibrary/js/loans/index.js
@@ -1,5 +1,5 @@
 export function initLoans() {
-  window.q.push(function() {
+  $(function() {
     $("a.leave").on('click', function() {
       var title = $(this).parents("tr").find(".book").text();
       $("#leave-waitinglist-dialog strong").text(title);

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -124,17 +124,6 @@ $else:
     $else:
         <div id="leave-waitinglist-dialog" class="hidden dialog"
              title="$_('Leave the Waiting List')">$:_('Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?')</div>
-        <script type="text/javascript">
-        window.q.push(function() {
-            \$("a.leave").on('click', function() {
-                var title = \$(this).parents("tr").find(".book").text();
-                \$("#leave-waitinglist-dialog strong").text(title);
-                \$("#leave-waitinglist-dialog")
-                    .data("origin", \$(this))
-                    .dialog("open");
-            });
-        });
-        </script>
         <div class="borrow borrow-table collapse waitinglist">
           <table>
               <thead>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8378

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR achieves a refactor of the codebase.

### Technical
<!-- What should be noted about the implementation? -->
The implementation moves inline JavaScript from `loans.html` to a separate module in `openlibrary/plugins/openlibrary/js/loans/index.js`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To verify the changes:
1. Navigate to the loans page.
2. Confirm that all interactive elements function as expected without any JavaScript errors in the console.
3. Ensure that the `Leave the waiting list` feature works correctly after the JavaScript has been modularized.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
